### PR TITLE
Add date converter with Hebrew and zodiac info

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
             <li><a href="#information-one">Information</a></li>
             <li><a href="#about">About</a></li>
             <li><a href="#contact">Contact</a></li>
+            <li><a href="zodiac.html">Date Converter</a></li>
         </ul>
     </nav>
     </header>

--- a/zodiac.css
+++ b/zodiac.css
@@ -1,0 +1,58 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@300;600&display=swap');
+body {
+    margin: 0;
+    font-family: 'Poppins', sans-serif;
+    background: linear-gradient(135deg, #f5f7fa, #c3cfe2);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.converter-container {
+    background: #ffffff;
+    padding: 2rem 3rem;
+    border-radius: 8px;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+    text-align: center;
+    animation: fadeIn 1s ease forwards;
+}
+
+input[type="date"] {
+    padding: 0.5rem;
+    font-size: 1rem;
+    margin: 1rem 0;
+}
+
+button {
+    padding: 0.5rem 1rem;
+    font-size: 1rem;
+    color: #fff;
+    background: #ff4081;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background 0.3s ease;
+}
+
+button:hover {
+    background: #f50057;
+}
+
+#results {
+    margin-top: 1.5rem;
+    opacity: 0;
+}
+
+#results.show {
+    animation: fadeIn 1s forwards;
+}
+
+.hidden {
+    display: none;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}

--- a/zodiac.html
+++ b/zodiac.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Date Converter</title>
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="zodiac.css">
+</head>
+<body>
+    <div class="converter-container">
+        <h1>Date Converter</h1>
+        <input type="date" id="dateInput">
+        <button id="convertBtn" class="btn">Convert</button>
+        <div id="results" class="hidden">
+            <p>Hebrew Date: <span id="hebrew"></span></p>
+            <p>Western Zodiac: <span id="western"></span></p>
+            <p>Chinese Zodiac: <span id="chinese"></span></p>
+        </div>
+    </div>
+    <script src="zodiac.js"></script>
+</body>
+</html>

--- a/zodiac.js
+++ b/zodiac.js
@@ -1,0 +1,84 @@
+function getWesternZodiac(date) {
+    const day = date.getDate();
+    const month = date.getMonth() + 1; // months start at 0
+    if ((month == 1 && day >= 20) || (month == 2 && day <= 18)) return 'Aquarius';
+    if ((month == 2 && day >= 19) || (month == 3 && day <= 20)) return 'Pisces';
+    if ((month == 3 && day >= 21) || (month == 4 && day <= 19)) return 'Aries';
+    if ((month == 4 && day >= 20) || (month == 5 && day <= 20)) return 'Taurus';
+    if ((month == 5 && day >= 21) || (month == 6 && day <= 20)) return 'Gemini';
+    if ((month == 6 && day >= 21) || (month == 7 && day <= 22)) return 'Cancer';
+    if ((month == 7 && day >= 23) || (month == 8 && day <= 22)) return 'Leo';
+    if ((month == 8 && day >= 23) || (month == 9 && day <= 22)) return 'Virgo';
+    if ((month == 9 && day >= 23) || (month == 10 && day <= 22)) return 'Libra';
+    if ((month == 10 && day >= 23) || (month == 11 && day <= 21)) return 'Scorpio';
+    if ((month == 11 && day >= 22) || (month == 12 && day <= 21)) return 'Sagittarius';
+    return 'Capricorn';
+}
+
+function getChineseZodiac(year) {
+    const animals = ['Rat','Ox','Tiger','Rabbit','Dragon','Snake','Horse','Goat','Monkey','Rooster','Dog','Pig'];
+    return animals[(year - 4) % 12];
+}
+
+const GERESH = '\u05F3'; // ׳
+const GERSHAYIM = '\u05F4'; // ״
+
+function numberToHebrew(num) {
+    const units = ['', 'א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט'];
+    const tens = ['', 'י', 'כ', 'ל', 'מ', 'נ', 'ס', 'ע', 'פ', 'צ'];
+    const hundreds = ['', 'ק', 'ר', 'ש', 'ת', 'תק', 'תר', 'תש', 'תת', 'תתק'];
+
+    let result = '';
+    const h = Math.floor(num / 100);
+    if (h) result += hundreds[h];
+
+    let rem = num % 100;
+    if (rem === 15) result += 'טו';
+    else if (rem === 16) result += 'טז';
+    else {
+        const t = Math.floor(rem / 10);
+        if (t) result += tens[t];
+        const o = rem % 10;
+        if (o) result += units[o];
+    }
+
+    if (result.length > 1) result = result.slice(0, -1) + GERSHAYIM + result.slice(-1);
+    else if (result.length === 1) result += GERESH;
+    return result;
+}
+
+function formatHebrewDate(date) {
+    const parts = new Intl.DateTimeFormat('he-u-ca-hebrew', {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric'
+    }).formatToParts(date);
+
+    let day = 0, month = '', year = 0;
+    for (const p of parts) {
+        if (p.type === 'day') day = parseInt(p.value, 10);
+        else if (p.type === 'month') month = p.value;
+        else if (p.type === 'year') year = parseInt(p.value, 10);
+    }
+
+    const thousands = Math.floor(year / 1000);
+    const rest = year % 1000;
+    const yearHeb = (thousands ? numberToHebrew(thousands) : '') + numberToHebrew(rest);
+
+    return `${numberToHebrew(day)} ב${month} ${yearHeb}`;
+}
+
+document.getElementById('convertBtn').addEventListener('click', function () {
+    const value = document.getElementById('dateInput').value;
+    if (!value) return;
+    const date = new Date(value + 'T00:00:00');
+    const hebrew = formatHebrewDate(date);
+    const western = getWesternZodiac(date);
+    const chinese = getChineseZodiac(date.getFullYear());
+    document.getElementById('hebrew').textContent = hebrew;
+    document.getElementById('western').textContent = western;
+    document.getElementById('chinese').textContent = chinese;
+    const results = document.getElementById('results');
+    results.classList.remove('hidden');
+    results.classList.add('show');
+});


### PR DESCRIPTION
## Summary
- add new Zodiac Date Converter page
- create basic styling and logic for converting Gregorian date to Hebrew date
- compute Western and Chinese zodiac signs
- link new page from the main navigation
- improve Hebrew date output in letters

## Testing
- `node -e "const d=new Date(1979,6,13);const parts=new Intl.DateTimeFormat('he-u-ca-hebrew',{day:'numeric',month:'long',year:'numeric'}).format(d);console.log(parts)"`
- `node - <<'NODE'
const fs = require('fs');
const code = fs.readFileSync('zodiac.js','utf8');
const vm = require('vm');
const sandbox = {window:{},document:{getElementById:()=>({addEventListener:()=>{}})},console};
vm.createContext(sandbox);
vm.runInContext(code, sandbox);
console.log(sandbox.formatHebrewDate(new Date('1979-07-13')));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_684176a2c5c08332bb547be0097b261c